### PR TITLE
Update upstream

### DIFF
--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -11,9 +11,11 @@
  limitations under the License.
 */
 
+import {CacheExpiration} from './CacheExpiration.mjs';
 import {WorkboxError} from 'workbox-core/_private/WorkboxError.mjs';
 import {assert} from 'workbox-core/_private/assert.mjs';
-import {CacheExpiration} from './CacheExpiration.mjs';
+import {cacheNames} from 'workbox-core/_private/cacheNames.mjs';
+
 import './_version.mjs';
 
 /**
@@ -86,6 +88,10 @@ class Plugin {
    * @private
    */
   _getCacheExpiration(cacheName) {
+    if (cacheName === cacheNames.getRuntimeName()) {
+      throw new WorkboxError('expire-custom-caches-only');
+    }
+
     let cacheExpiration = this._cacheExpirations.get(cacheName);
     if (!cacheExpiration) {
       cacheExpiration = new CacheExpiration(cacheName, this._config);

--- a/packages/workbox-core/models/messages/messages.mjs
+++ b/packages/workbox-core/models/messages/messages.mjs
@@ -179,6 +179,10 @@ export default {
     return `The arguments passed into responsesAreSame() appear to be ` +
       `invalid. Please ensure valid Responses are used.`;
   },
+  'expire-custom-caches-only': () => {
+    return `You must provide a 'cacheName' property when using the ` +
+      `expiration plugin with a runtime caching strategy.`;
+  },
   'unit-must-be-bytes': ({normalizedRangeHeader}) => {
     if (!normalizedRangeHeader) {
       throw new Error(`Unexpected input to 'unit-must-be-bytes' error.`);

--- a/packages/workbox-strategies/_default.mjs
+++ b/packages/workbox-strategies/_default.mjs
@@ -18,6 +18,7 @@ import {CacheOnly} from './CacheOnly.mjs';
 import {NetworkFirst} from './NetworkFirst.mjs';
 import {NetworkOnly} from './NetworkOnly.mjs';
 import {StaleWhileRevalidate} from './StaleWhileRevalidate.mjs';
+
 import './_version.mjs';
 
 /**

--- a/test/workbox-cache-expiration/node/test-Plugin.mjs
+++ b/test/workbox-cache-expiration/node/test-Plugin.mjs
@@ -19,6 +19,7 @@ import {devOnly} from '../../../infra/testing/env-it';
 
 import {Plugin} from '../../../packages/workbox-cache-expiration/Plugin.mjs';
 import {CacheExpiration} from '../../../packages/workbox-cache-expiration/CacheExpiration.mjs';
+import {cacheNames} from '../../../packages/workbox-core/_private/cacheNames.mjs';
 
 describe(`[workbox-cache-expiration] Plugin`, function() {
   const sandbox = sinon.sandbox.create();
@@ -154,6 +155,16 @@ describe(`[workbox-cache-expiration] Plugin`, function() {
       expect(CacheExpiration.prototype.updateTimestamp.callCount).to.equal(1);
       expect(CacheExpiration.prototype.updateTimestamp.args[0][0]).to.equal(url);
       expect(CacheExpiration.prototype.expireEntries.callCount).to.equal(1);
+    });
+  });
+
+  describe(`_getCacheExpiration()`, function() {
+    it(`should reject when called with the default runtime cache name`, async function() {
+      const plugin = new Plugin({maxAgeSeconds: 1});
+      await expectError(
+        () => plugin._getCacheExpiration(cacheNames.getRuntimeName()),
+        'expire-custom-caches-only'
+      );
     });
   });
 });

--- a/test/workbox-strategies/node/test-default.mjs
+++ b/test/workbox-strategies/node/test-default.mjs
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+
 import {CacheFirst, CacheOnly, NetworkFirst, NetworkOnly, StaleWhileRevalidate} from '../../../packages/workbox-strategies/_public.mjs';
 import strategies from '../../../packages/workbox-strategies/_default.mjs';
 
@@ -65,7 +66,7 @@ describe(`[workbox-strategies] Default Export`, function() {
     });
   });
 
-  describe(`StaleWhileRevalidate()`, function() {
+  describe(`staleWhileRevalidate()`, function() {
     it(`should return a StaleWhileRevalidate instance`, function() {
       const strategy = strategies.staleWhileRevalidate();
       expect(strategy).to.be.an.instanceof(StaleWhileRevalidate);
@@ -75,7 +76,7 @@ describe(`[workbox-strategies] Default Export`, function() {
       const strategy = strategies.staleWhileRevalidate({
         plugins: [CUSTOM_PLUGIN],
       });
-      // Stale while revalidate adds a plugin for opaque resposnes
+      // Stale while revalidate adds a plugin for opaque responses.
       expect(strategy._plugins.length).to.equal(2);
       expect(strategy._plugins[1]).to.equal(CUSTOM_PLUGIN);
     });


### PR DESCRIPTION
…#1079)

* Throw a WorkboxError when cacheExpiration is used without cacheName.

* Include the message.

* Review feedback.

* Linting.

R: @jeffposnick @addyosmani @gauntface

Fixes #*issue number*

*Description of what's changed/fixed.*

*Please ensure that `gulp lint test` passes locally prior to filing a PR!*
