### PR TITLE
Update upstream

### DIFF
--- a/infra/testing/sw-env-mocks/Headers.js
+++ b/infra/testing/sw-env-mocks/Headers.js
@@ -26,7 +26,7 @@ class Headers {
   }
 
   get(key) {
-    return this.obj[key];
+    return this.has(key) ? this.obj[key] : null;
   }
 
   set(key, value) {

--- a/packages/workbox-cache-expiration/Plugin.mjs
+++ b/packages/workbox-cache-expiration/Plugin.mjs
@@ -169,6 +169,10 @@ class Plugin {
    * @private
    */
   _getDateHeaderTimestamp(cachedResponse) {
+    if (!cachedResponse.headers.has('date')) {
+      return null;
+    }
+
     const dateHeader = cachedResponse.headers.get('date');
     const parsedDate = new Date(dateHeader);
     const headerTime = parsedDate.getTime();

--- a/test/workbox-cache-expiration/node/test-Plugin.mjs
+++ b/test/workbox-cache-expiration/node/test-Plugin.mjs
@@ -131,12 +131,20 @@ describe(`[workbox-cache-expiration] Plugin`, function() {
       expect(isFresh).to.equal(true);
     });
 
-    it(`should return true when there is not Date header`, function() {
+    it(`should return true when there is no Date header`, function() {
       const plugin = new Plugin({maxAgeSeconds: 1});
       const isFresh = plugin._isResponseDateFresh(new Response('Hi', {
         // TODO: Remove this when https://github.com/pinterest/service-workers/issues/72
         // is fixed.
         headers: {},
+      }));
+      expect(isFresh).to.equal(true);
+    });
+
+    it(`should return true when the Date header is invalid`, function() {
+      const plugin = new Plugin({maxAgeSeconds: 1});
+      const isFresh = plugin._isResponseDateFresh(new Response('Hi', {
+        headers: {date: 'invalid header'},
       }));
       expect(isFresh).to.equal(true);
     });


### PR DESCRIPTION
…aderTimeStamp` would return 0, causing response to always be expired (#1422)

Also fixed Headers mock get method to return null if header did not exist

R: @jeffposnick @addyosmani @gauntface

Fixes #*issue number*

*Description of what's changed/fixed.*

*Please ensure that `gulp lint test` passes locally prior to filing a PR!*
