### PR TITLE
Update upstream

### DIFF
--- a/packages/workbox-build/package-lock.json
+++ b/packages/workbox-build/package-lock.json
@@ -1,15 +1,44 @@
 {
-  "requires": true,
+  "name": "workbox-build",
+  "version": "3.4.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "babel-extract-comments": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+      "integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
+      "requires": {
+        "babylon": "6.18.0"
+      }
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
       }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -21,7 +50,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -30,7 +59,7 @@
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
       "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
       "requires": {
-        "babel-runtime": "^6.18.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "concat-map": {
@@ -48,9 +77,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
       "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs.realpath": {
@@ -58,17 +87,22 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug=="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -86,8 +120,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -95,12 +129,22 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+    },
     "isemail": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
       "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
       "requires": {
-        "punycode": "2.x.x"
+        "punycode": "2.1.0"
       }
     },
     "joi": {
@@ -108,9 +152,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-11.1.1.tgz",
       "integrity": "sha512-hffQzH42mYLvUCqhUPZZGegiiIjVvHcOV8mrxXPci8qZFOp2sHK4778GPyI3ZlvqTOHs8qZN6DovDnBR1slO4g==",
       "requires": {
-        "hoek": "4.x.x",
-        "isemail": "3.x.x",
-        "topo": "2.x.x"
+        "hoek": "4.2.0",
+        "isemail": "3.0.0",
+        "topo": "2.0.2"
       }
     },
     "jsonfile": {
@@ -118,7 +162,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "lodash._reinterpolate": {
@@ -131,8 +175,8 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -140,7 +184,7 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "minimatch": {
@@ -148,7 +192,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "once": {
@@ -156,7 +200,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "path-is-absolute": {
@@ -179,18 +223,138 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
       "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
+    "stringify-object": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
+    },
+    "strip-comments": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
+      "integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
+      "requires": {
+        "babel-extract-comments": "1.0.0",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
+      }
+    },
     "topo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.0"
       }
     },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "workbox-background-sync": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.4.1.tgz",
+      "integrity": "sha512-Ksb2nCg/2wOyBMhSBqSbtCEwuKaf5sHgTY8HdCxbLIQSzDh9/qZqg+1P11CKlgJmHtje3EK3B8EsrzukZo10xA==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-broadcast-cache-update": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.4.1.tgz",
+      "integrity": "sha512-+WPqHFk4ER4RICAMOYrP88yBbiUQ9ZOFNruqwbl9YxGfbADV16OEGmYpIs+Az6HT6DNDCx8eQqtFiaG8N3O11Q==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-cache-expiration": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.4.1.tgz",
+      "integrity": "sha512-AzOPB+dwfxg13v4+q5jWkxsw/oim9mPIzew1anu8ALA3vB8qySaJJToXp+ZlVh/Co+sDK0tgjlB76bvSFHgZ4g==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-cacheable-response": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.4.1.tgz",
+      "integrity": "sha512-SO2k830JT93GitPwc5tzJI49d9VwyVxXwiCbyvo+Sqo+dcvWSrmpsyuXdzy6zuasbPrWUF0vsFj1uGtZbOym8Q==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-core": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.4.1.tgz",
+      "integrity": "sha512-RqMV2so9/KLAu9aUxJ/85pvrZMUn835B8zoHmqRyGNetiDr8B1zSBeKXPZAjFlX/88KdhizNwiRlJtqlXtM4tA=="
+    },
+    "workbox-google-analytics": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.4.1.tgz",
+      "integrity": "sha512-w6Osz2Rr1/4+W0gram6Yzg6NNWLvHP51RwFCNAZSpEnipr0qSEtD+yvwrdaHfiJHWhcK2yH/V6E1MV8Hrczmvw==",
+      "requires": {
+        "workbox-background-sync": "3.4.1",
+        "workbox-core": "3.4.1",
+        "workbox-routing": "3.4.1",
+        "workbox-strategies": "3.4.1"
+      }
+    },
+    "workbox-navigation-preload": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.4.1.tgz",
+      "integrity": "sha512-P3FHAcyZ8db2QiW/BpMkuosC1OkRsEoUaT7U3QOgg7JSjjsJoEbF7G5olNe+P+PQYdVhJA7TCuptI6dy2gLS/g==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-precaching": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.4.1.tgz",
+      "integrity": "sha512-ykU2mly9xmRrCW6iMeUWYydWiso/WSE16+7wponhI0WC53jiQSt2JvykWm0VpWFJSs6ZTSZZ1WK2gs/brRnPug==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-range-requests": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.4.1.tgz",
+      "integrity": "sha512-ktgjl6liZrRTmQjPw1pBblC5umHnTb8XcvFVitdGz17B23jj6cUV4EXzEU2ilGn6jO6+MLV1Vn9SWajtLSc2Gg==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-routing": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.4.1.tgz",
+      "integrity": "sha512-6j6cXMUYfMPYTycmElxVOfBTr6WV5zAn/JUFJ7GJ5pYFIE9cqztprnrcOsWJ42+AiNIeHPbKfyIWE/rZVviMxQ==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-strategies": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.4.1.tgz",
+      "integrity": "sha512-7mJuzFsgejflzjfnChXCFma1S0mi9WC6wlSU2wE50M7bJmEuf9A3j3MojpKcsTEM58hbhbnU6QF/u9iIV7+opw==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-streams": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.4.1.tgz",
+      "integrity": "sha512-krw+5bp+oe9Za5c6WlTWM3SgZGfExYcqRSn1gsyYgKeXmgzTwf+DOb5Lwult0KSWlJfq8B3Wk7sW8Sl7lRzSbA==",
+      "requires": {
+        "workbox-core": "3.4.1"
+      }
+    },
+    "workbox-sw": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.4.1.tgz",
+      "integrity": "sha512-nnm2by5oaQGXRH7x4M5/n2KqjUGVmP4P8azUmJITnYa3DWVYn/ghDg3LJ5+h4A28vYq9V6ePgATaEPfb6B5pug=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/packages/workbox-build/package.json
+++ b/packages/workbox-build/package.json
@@ -27,6 +27,8 @@
     "joi": "^11.1.1",
     "lodash.template": "^4.4.0",
     "pretty-bytes": "^4.0.2",
+    "stringify-object": "^3.2.2",
+    "strip-comments": "^1.0.2",
     "workbox-background-sync": "^3.4.1",
     "workbox-broadcast-cache-update": "^3.4.1",
     "workbox-cache-expiration": "^3.4.1",

--- a/packages/workbox-build/src/lib/runtime-caching-converter.js
+++ b/packages/workbox-build/src/lib/runtime-caching-converter.js
@@ -15,8 +15,10 @@
 */
 
 const ol = require('common-tags').oneLine;
-
+const objectStringify = require('stringify-object');
+const stripComments = require('strip-comments');
 const errors = require('./errors');
+
 
 /**
  * Given a set of options that configures `sw-toolbox`'s behavior, convert it
@@ -31,7 +33,13 @@ const errors = require('./errors');
 function getOptionsString(options = {}) {
   let plugins = [];
   if (options.plugins) {
-    plugins = options.plugins.map((plugin) => JSON.stringify(plugin));
+    // Using libs because JSON.stringify won't handle functions
+    plugins = options.plugins.map((plugin) =>
+      objectStringify(plugin, {
+        transform: (_obj, _prop, str) => stripComments(str),
+      })
+    );
+
     delete options.plugins;
   }
 

--- a/test/workbox-build/node/lib/runtime-caching-converter.js
+++ b/test/workbox-build/node/lib/runtime-caching-converter.js
@@ -44,7 +44,6 @@ function validate(runtimeCachingOptions, convertedOptions) {
 
   const script = new vm.Script(convertedOptions.join('\n'));
   script.runInNewContext(globalScope);
-
   runtimeCachingOptions.forEach((runtimeCachingOption, i) => {
     const registerRouteCall = globalScope.workbox.routing.registerRoute.getCall(i);
     expect(registerRouteCall.args[0]).to.eql(runtimeCachingOption.urlPattern);
@@ -229,5 +228,81 @@ describe(`[workbox-build] src/lib/utils/runtime-caching-converter.js`, function(
 
     const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
     validate(runtimeCachingOptions, convertedOptions);
+  });
+
+  it(`should support custom plugins`, function() {
+    const runtimeCachingOptions = [{
+        urlPattern: /abc/,
+        handler: 'cacheFirst',
+        options: {
+          plugins: [{
+            cacheWillUpdate: async ({request, response}) => {
+                return response;
+              },
+              cacheDidUpdate: async ({cacheName, request, oldResponse, newResponse}) => {},
+              cachedResponseWillBeUsed: async ({cacheName, request, matchOptions, cachedResponse}) => {
+                return cachedResponse;
+              },
+              requestWillFetch: async ({request}) => {
+                return request;
+              },
+              fetchDidFail: async ({originalRequest, request, error}) => {},
+          }],
+        },
+    }];
+
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    expect(convertedOptions[0].includes('cacheWillUpdate: async')).to.true;
+    expect(convertedOptions[0].includes('cacheDidUpdate: async')).to.true;
+    expect(convertedOptions[0].includes('cachedResponseWillBeUsed: async')).to.true;
+    expect(convertedOptions[0].includes('requestWillFetch: async')).to.true;
+    expect(convertedOptions[0].includes('fetchDidFail: async')).to.true;
+  });
+
+  it(`should strip comments on custom plugins`, function() {
+    const runtimeCachingOptions = [{
+        urlPattern: /abc/,
+        handler: 'cacheFirst',
+        options: {
+          plugins: [{
+            cacheWillUpdate: async ({request, response}) => {
+                // Commenting
+                return response;
+            },
+            cachedResponseWillBeUsed: async ({cacheName, request, matchOptions, cachedResponse}) => {
+                /* Commenting */
+                return cachedResponse;
+            },
+          }],
+        },
+    }];
+
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    expect(convertedOptions[0].includes('// Commenting')).to.false;
+    expect(convertedOptions[0].includes('/* Commenting */')).to.false;
+  });
+
+  it(`should keep contents with // that are not comments`, function() {
+    const runtimeCachingOptions = [{
+        urlPattern: /abc/,
+        handler: 'cacheFirst',
+        options: {
+          plugins: [{
+            cacheWillUpdate: async ({request, response}) => {
+                // Commenting
+
+                if (request.url === 'https://test.com') {
+                    return null;
+                }
+
+                return response;
+            },
+          }],
+        },
+    }];
+
+    const convertedOptions = runtimeCachingConverter(runtimeCachingOptions);
+    expect(convertedOptions[0].includes('// Commenting')).to.false;
+    expect(convertedOptions[0].includes('https://test.com')).to.true;
   });
 });


### PR DESCRIPTION
…ox-webpack-plugin (#1598)

* fix empty object on custom plugins

* strip comments when parsing custom plugins

* use regex instead of strip-comments lib

* add test cases for custom plugins

* check if function content remains on custom plugin tests

* fix misshandled strings with //  on runtime-caching-converter

* add test case to misshandled // on runtime-caching-converter

* fix identation on runtime-caching-converter changes

R: @jeffposnick @addyosmani @gauntface

Fixes #*issue number*

*Description of what's changed/fixed.*

*Please ensure that `gulp lint test` passes locally prior to filing a PR!*
